### PR TITLE
Remove entry-level option declaration for url, doi, eprint

### DIFF
--- a/oscola.bbx
+++ b/oscola.bbx
@@ -131,12 +131,6 @@
 \newboolean{bbx@year-essential}\setboolean{bbx@year-essential}{false}
 
 % Entry options
-\DeclareEntryOption{url}[true]{%
-  \settoggle{bbx:url}{#1}}
-\DeclareEntryOption{doi}[true]{%
-  \settoggle{bbx:doi}{#1}}
-\DeclareEntryOption{eprint}[true]{%
-  \settoggle{bbx:eprint}{#1}}
 \DeclareEntryOption{scottish-style}[true]{%
   \settoggle{bbx:scotstyle}{#1}}
 \DeclareEntryOption{no-ibid}[true]{%


### PR DESCRIPTION
`biblatex` 3.13 provides these by default (https://github.com/plk/biblatex/pull/877). Unfortunately, the declarations cause an error now since `biblatex` checks for existing options and doesn't silently overwrite them.