### PR TITLE
Fix typo in Table 1: Virtual Indexes for echr cases

### DIFF
--- a/oscola.tex
+++ b/oscola.tex
@@ -981,7 +981,7 @@ Scottish cases                       & \texttt{sccases}      & alphabetical\\
 Northern Irish cases                 & \texttt{nicases}      & alphabetical\\
 EU cases                             & \texttt{eucases}      & alphabetical \\
                                      & \texttt{eucasesnum}   & by case number \\
-ECHR cases                           & \texttt{echrcase}     & alphabetical \\
+ECHR cases                           & \texttt{echrcases}     & alphabetical \\
 ECHR Commission decisions            & \texttt{echrcasescomm}& alphabetical \\
 International cases                  & \texttt{pilcases}     & alphabetical \\
 Australian cases					 & \texttt{aucases}      & alphabetical \\


### PR DESCRIPTION
The documentation states that the hook is 'echrcase' but it should read 'echrcases'.